### PR TITLE
Improve 'What you'll need' section of Intro page

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -21,12 +21,14 @@ If you’re not familiar with Unity, or need a refresher, here are a few helpful
 
 [Unity Universal Render Pipeline Documentation](https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@10.9/manual/index.html)
 
-
 ### What you'll need
 
-- [Unity](https://unity.com/download) version 2021.3.19f1
-  - When installing Unity, you are recommended to use the Unity Hub for managing your projects.
-- [Standalone PC Rec Room client](https://rec.net/settings/recroomstudio) This comes with the Rec Room Studio installer
+- A Windows PC running Windows 10 or newer
+- [Unity Hub](https://unity.com/download)
+- [Unity Version 2021.3.29f1](unityhub://2021.3.29f1/204d6dc9ae1c)
+  - When installing Unity, you are recommended to use the link above which will launch Unity Hub too the installer for proper version.
+  - If you need to manually install, you can find the download [here](https://unity.com/releases/editor/whats-new/2021.3.29)
+- Rec Room Client [Standalone PC](https://rec.net/settings/recroomstudio) or [Steam](https://store.steampowered.com/app/471710/Rec_Room/) version
 
 
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -28,7 +28,7 @@ If you’re not familiar with Unity, or need a refresher, here are a few helpful
 - [Unity Version 2021.3.29f1](unityhub://2021.3.29f1/204d6dc9ae1c)
   - When installing Unity, you are recommended to use the link above which will launch Unity Hub too the installer for proper version.
   - If you need to manually install, you can find the download [here](https://unity.com/releases/editor/whats-new/2021.3.29)
-- Rec Room Client [Standalone PC](https://rec.net/settings/recroomstudio) or [Steam](https://store.steampowered.com/app/471710/Rec_Room/) version
+- Rec Room Client [Standalone PC](https://rec.net/download) or [Steam](https://store.steampowered.com/app/471710/Rec_Room/) version
 
 
 


### PR DESCRIPTION
- Fix 'what you'll need' section was incorrectly saying 2021.3.19f1 rather than 2021.3.29f1.
- Add separate download links for Unity Hub & Unity Editor 2021.3.29f1
- Add Windows PC & Win 10+ as a requirement
- Change section about Rec Room Client to include links to Standalone or Steam downloader.
